### PR TITLE
Better Bash variable references ensuring better errors with empty var…

### DIFF
--- a/resources/analysisTools/copyNumberEstimationWorkflow/correct_gc_bias.sh
+++ b/resources/analysisTools/copyNumberEstimationWorkflow/correct_gc_bias.sh
@@ -4,25 +4,25 @@
 # Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/ACEseqWorkflow/LICENSE.txt).
 
 
-tmp_corrected_windowfile=${FILENAME_GC_CORRECTED_WINDOWS}.tmp
-tmp_corrected_table=${FILENAME_GC_CORRECTED_QUALITY}.tmp
-corrected_table_slim=${FILENAME_GC_CORRECTED_QUALITY}.slim.txt
+tmp_corrected_windowfile="$FILENAME_GC_CORRECTED_WINDOWS.tmp"
+tmp_corrected_table="$FILENAME_GC_CORRECTED_QUALITY.tmp"
+corrected_table_slim="$FILENAME_GC_CORRECTED_QUALITY.slim.txt"
 
-${RSCRIPT_BINARY} ${TOOL_CORRECT_GC_BIAS_R} \
-	--windowFile	${FILENAME_COV_WINDOWS_WG} \
-	--timefile	${REPLICATION_TIME_FILE} \
-	--chrLengthFile	${CHROMOSOME_LENGTH_FILE} \
-	--pid		${PID} \
-	--email		${EMAIL} \
-	--outfile	${tmp_corrected_windowfile} \
-	--corPlot	${FILENAME_GC_CORRECT_PLOT} \
-	--corTab	${tmp_corrected_table} \
-	--qcTab		${corrected_table_slim} \
-	--gcFile	${GC_CONTENT_FILE} \
-	--outDir	${aceseqOutputDirectory} \
-	--lowess_f	${LOWESS_F} \
-	--scaleFactor	${SCALE_FACTOR} \
-	--coverageYlims ${COVERAGEPLOT_YLIMS}
+$RSCRIPT_BINARY "$TOOL_CORRECT_GC_BIAS_R" \
+	--windowFile	"$FILENAME_COV_WINDOWS_WG" \
+	--timefile	"$REPLICATION_TIME_FILE" \
+	--chrLengthFile	"$CHROMOSOME_LENGTH_FILE" \
+	--pid		"$PID" \
+	--email		"$EMAIL" \
+	--outfile	"$tmp_corrected_windowfile" \
+	--corPlot	"$FILENAME_GC_CORRECT_PLOT" \
+	--corTab	"$tmp_corrected_table" \
+	--qcTab		"$corrected_table_slim" \
+	--gcFile	"$GC_CONTENT_FILE" \
+	--outDir	"$aceseqOutputDirectory" \
+	--lowess_f	"$LOWESS_F" \
+	--scaleFactor	"$SCALE_FACTOR" \
+	--coverageYlims "$COVERAGEPLOT_YLIMS"
 
 
 
@@ -32,16 +32,16 @@ then
 	exit 2
 fi	
 
-mv ${tmp_corrected_windowfile} ${FILENAME_GC_CORRECTED_WINDOWS}
-mv ${tmp_corrected_table} ${FILENAME_GC_CORRECTED_QUALITY}
+mv "$tmp_corrected_windowfile" "$FILENAME_GC_CORRECTED_WINDOWS"
+mv "$tmp_corrected_table" "$FILENAME_GC_CORRECTED_QUALITY"
 
-tmp_qc_value_file=${FILENAME_QC_GC_CORRECTION_JSON}.tmp
+tmp_qc_value_file="$FILENAME_QC_GC_CORRECTION_JSON}.tmp"
 
-${PYTHON_BINARY} ${TOOL_CONVERT_TO_JSON} \
-	--file 	${corrected_table_slim} \
-	--id 	${pid} \
-	--out 	${tmp_qc_value_file}\
-	--key	${GC_bias_json_key}
+$PYTHON_BINARY "$TOOL_CONVERT_TO_JSON" \
+	--file 	"$corrected_table_slim" \
+	--id 	"$pid" \
+	--out 	"$tmp_qc_value_file" \
+	--key	"$GC_bias_json_key"
 
 if [[ $? != 0 ]]
 then
@@ -49,5 +49,5 @@ then
 	exit 2
 fi	
 
-mv ${tmp_qc_value_file} ${FILENAME_QC_GC_CORRECTION_JSON}
+mv "$tmp_qc_value_file" "$FILENAME_QC_GC_CORRECTION_JSON"
 

--- a/resources/analysisTools/copyNumberEstimationWorkflow/correct_gc_bias_1kb.sh
+++ b/resources/analysisTools/copyNumberEstimationWorkflow/correct_gc_bias_1kb.sh
@@ -4,20 +4,20 @@
 # Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/ACEseqWorkflow/LICENSE.txt).
 
 
-tmp_corrected_windowfile=${FILENAME_GC_CORRECTED_WINDOWS}.tmp
+tmp_corrected_windowfile="$FILENAME_GC_CORRECTED_WINDOWS.tmp"
 
-${RSCRIPT_BINARY} ${TOOL_CORRECT_GC_BIAS_R} \
-	--windowFile ${cnvSnpOutputDirectory}/${PID}.all.cnv.chr*.tab \
-	--timefile   ${REPLICATION_TIME_FILE} \
-	--chrLengthFile ${CHROMOSOME_LENGTH_FILE} \
-	--pid	     ${PID} \
-	--email      ${EMAIL} \
-	--outfile    ${tmp_corrected_windowfile} \
-	--corPlot    ${FILENAME_GC_CORRECT_PLOT} \
-	--gcFile     ${GC_CONTENT_FILE} \
-	--outDir     ${aceseqOutputDirectory} \
-	--lowess_f   ${LOWESS_F} \
-	--scaleFactor ${SCALE_FACTOR}
+$RSCRIPT_BINARY "$TOOL_CORRECT_GC_BIAS_R \
+	--windowFile "$cnvSnpOutputDirectory/$PID".all.cnv.chr*.tab \
+	--timefile   "$REPLICATION_TIME_FILE" \
+	--chrLengthFile $CHROMOSOME_LENGTH_FILE" \
+	--pid	     "$PID" \
+	--email      "$EMAIL" \
+	--outfile    "$tmp_corrected_windowfile" \
+	--corPlot    "$FILENAME_GC_CORRECT_PLOT" \
+	--gcFile     "$GC_CONTENT_FILE" \
+	--outDir     "$aceseqOutputDirectory" \
+	--lowess_f   "$LOWESS_F" \
+	--scaleFactor "$SCALE_FACTOR"
 
 
 
@@ -27,4 +27,4 @@ then
 	exit 2
 fi	
 
-mv ${tmp_corrected_windowfile} ${FILENAME_GC_CORRECTED_WINDOWS}
+mv "$tmp_corrected_windowfile" "$FILENAME_GC_CORRECTED_WINDOWS"


### PR DESCRIPTION
…iable values.

With `${varName}` an empty variable will be inserted as nothing, meaning that all following variables are shifted left.

With `"${varName}"` this is not happening, but the braces `{}` are superfluous. Therefore my proposed solution

`$varName`.